### PR TITLE
fix(#3): Fix relay shut down when only one metric is sent

### DIFF
--- a/lib/listeners/statful.js
+++ b/lib/listeners/statful.js
@@ -3,16 +3,6 @@ var Logger = require('../logger');
 var Utils = require('../utils');
 
 /**
- * Counts the number of lines in the passed metrics lines
- *
- * @param metricLines A string containing lines of metrics
- * @returns {number}
- */
-function countMetricsInLines(metricLines) {
-    return metricLines.match(/\n/gi).length + 1;
-}
-
-/**
  * Builds up a function to dispatch incoming metrics
  *
  * @returns {Function}
@@ -29,7 +19,7 @@ function dispatchMetricLine(listener) {
             });
 
             if (listener.config.stats) {
-                listener.statfulClient.counter('metrics_flushed', countMetricsInLines(lines));
+                listener.statfulClient.counter('metrics_flushed', linesList.length);
             }
         }
     };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "https://github.com/statful/statful-relay.git"
   },
-  "version": "1.1.2",
+  "version": "1.1.3",
   "dependencies": {
     "bluebird": "3.4.6",
     "bunyan": "1.8.4",


### PR DESCRIPTION
Should fix: https://github.com/statful/statful-relay/issues/3